### PR TITLE
Fix NoneType Error

### DIFF
--- a/ginja/cli.py
+++ b/ginja/cli.py
@@ -118,10 +118,11 @@ def cli(env, src, dst):
                     if idx >= len(subdir_multiples):
                         _convert(vars)
                         return
-                    for v in subdir_multiples[idx]:
-                        n_vars = vars.copy()
-                        n_vars.update(v)
-                        _walk(idx+1, n_vars)
+                    if subdir_multiples and subdir_multiples[idx]:
+                        for v in subdir_multiples[idx]:
+                            n_vars = vars.copy()
+                            n_vars.update(v)
+                            _walk(idx+1, n_vars)
 
                 _walk(0, {})
             else:


### PR DESCRIPTION
Fix

```
$ ginja -e ...
Traceback (most recent call last):
  File "/usr/local/bin/ginja", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/ginja/cli.py", line 149, in cli
    _walk(0, {})
  File "/usr/local/lib/python3.9/site-packages/ginja/cli.py", line 143, in _walk
    for v in subdir_multiples[idx]:
TypeError: 'NoneType' object is not iterable
```